### PR TITLE
feat: Implement side-by-side diff viewers for moderation and version …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^20",
+        "@types/node": "^20.17.57",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "genkit-cli": "^1.8.0",
@@ -66,7 +66,7 @@
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5792,9 +5792,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
-      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -14218,9 +14218,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^20",
+    "@types/node": "^20.17.57",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "genkit-cli": "^1.8.0",
@@ -71,6 +71,6 @@
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5.8.3"
   }
 }

--- a/src/app/(app)/diff-test/page.tsx
+++ b/src/app/(app)/diff-test/page.tsx
@@ -1,0 +1,42 @@
+'use client'; // Required for client components in Next.js App Router
+
+import React from 'react';
+import { ExampleDiffViewer } from '@/components/ui/SideBySideDiffViewer'; // Assuming this is the exported example
+import { ExampleVersionHistoryViewer } from '@/components/ui/VersionHistoryDiffViewer'; // Assuming this is the exported example
+
+const DiffTestPage: React.FC = () => {
+  return (
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8 bg-gray-50 min-h-screen">
+      <header className="mb-8 text-center">
+        <h1 className="text-3xl font-bold text-gray-800">Diff Viewer Components Test Page</h1>
+        <p className="text-sm text-gray-600">
+          This page demonstrates the `SideBySideDiffViewer` and `VersionHistoryDiffViewer` components.
+        </p>
+      </header>
+
+      <section className="mb-12 p-6 bg-white shadow-lg rounded-lg">
+        <h2 className="text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+          SideBySideDiffViewer Test (Moderation Diff)
+        </h2>
+        <div className="overflow-x-auto">
+          <ExampleDiffViewer />
+        </div>
+      </section>
+
+      <section className="p-6 bg-white shadow-lg rounded-lg">
+        <h2 className="text-2xl font-semibold text-gray-700 mb-6 pb-2 border-b border-gray-300">
+          VersionHistoryDiffViewer Test
+        </h2>
+        <div className="overflow-x-auto">
+          <ExampleVersionHistoryViewer />
+        </div>
+      </section>
+
+      <footer className="mt-12 text-center text-xs text-gray-500">
+        <p>End of test page.</p>
+      </footer>
+    </div>
+  );
+};
+
+export default DiffTestPage;

--- a/src/components/ui/SideBySideDiffViewer.tsx
+++ b/src/components/ui/SideBySideDiffViewer.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import type { Politician, ContactInfo, PoliticalJourneyEvent, PartyAffiliation, Position, CommitteeMembership, EducationEntry, AssetDeclaration, CriminalRecord, PlaceOfBirth } from '@/types/gov';
+import type { FullEntityEditSuggestion, EntityFieldEditSuggestion } from '@/lib/schemas'; // Assuming schemas.ts is the source
+
+// --- START OF TEMPORARY MOCK DATA (due to issues with src/lib/mock-data.ts) ---
+
+const mockCurrentPolitician: Politician = {
+  id: 'politician-001',
+  name: 'Jane Doe',
+  nepaliName: 'जेन डो',
+  slug: 'jane-doe',
+  gender: 'Female',
+  dateOfBirth: '1975-03-15',
+  placeOfBirth: {
+    district: 'Kathmandu',
+    address: 'Old Baneshwor',
+  } as PlaceOfBirth,
+  partyId: 'party-002',
+  partyName: 'Progressive People Party',
+  photoUrl: 'https://example.com/jane-doe-old.jpg',
+  bio: 'Jane Doe has been a prominent figure in national politics for over two decades, known for her advocacy in social justice and environmental protection. She started her career as a local activist and quickly rose through the ranks of her party.',
+  province: 'Bagmati',
+  constituency: 'Kathmandu-1',
+  constituencyId: 'const-ktm-1',
+  isActiveInPolitics: true,
+  aliases: ['JD', "The People's Voice"],
+  positions: [
+    { title: 'Member of Parliament', startDate: '2010-05-01', endDate: '2015-05-01' },
+    { title: 'Minister of Environment', startDate: '2016-01-10', endDate: '2018-12-20' },
+  ] as Position[],
+  contactInfo: {
+    email: 'jane.doe.initial@example.com',
+    phone: '+977-9800000001',
+    officePhone: '+01-4000001',
+    address: 'MP Quarter, Kathmandu',
+    permanentAddress: 'Family Home, Pokhara',
+    website: 'http://janedoeofficial.np',
+    twitter: '@janedoe_np',
+    facebook: 'facebook.com/janedoeofficial',
+  } as ContactInfo,
+  politicalJourney: [
+    { date: '2000-01-15', event: 'Joined Progressive People Party', description: 'Became an active member of the youth wing.' },
+    { date: '2008-06-01', event: 'Elected as Local Ward Representative', description: 'Served for two years focusing on community projects.' },
+  ] as PoliticalJourneyEvent[],
+  partyAffiliations: [
+    { partyId: 'party-002', partyName: 'Progressive People Party', role: 'Senior Leader', startDate: '2000-01-15', endDate: 'Present' },
+  ] as PartyAffiliation[],
+  education: [
+    { institution: 'National University', degree: 'Masters in Political Science', field: 'Political Science', graduationYear: '1998' },
+  ] as EducationEntry[],
+  assetDeclarations: [
+    { year: 2022, description: 'House in Kathmandu, Land in Chitwan', value: 'NPR 50,000,000' },
+  ] as AssetDeclaration[],
+  criminalRecords: [] as CriminalRecord[],
+  committeeMemberships: [
+    { committeeName: 'Parliamentary Committee on Social Justice', role: 'Member', startDate: '2010-06-01', endDate: '2015-04-01' },
+  ] as CommitteeMembership[],
+  politicalIdeology: ['Social Democracy', 'Environmentalism'] as string[],
+  languagesSpoken: ['Nepali', 'English', 'Maithili'] as string[],
+  tags: ['social-justice', 'environment', 'women-rights'],
+  dataAiHint: 'Experienced female politician, serious demeanor, traditional attire',
+};
+
+const mockPendingEditPolitician: FullEntityEditSuggestion = {
+  id: 'suggestion-001',
+  suggesterId: 'user-002',
+  submittedAt: '2024-07-28T10:00:00Z',
+  status: 'PendingEntityUpdate',
+  reasonForChange: 'Updating profile with recent activities, new contact information, and expanded roles.',
+  evidenceUrl: 'https://example.com/news-article-jane-doe-new-role.html',
+  entityType: 'Politician',
+  entityId: 'politician-001',
+  suggestedData: {
+    // id: 'politician-001', // ID should not change in an update typically
+    name: 'Jane M. Doe (Updated)',
+    nepaliName: 'जेन एम. डो (अद्यावधिक)',
+    slug: 'jane-m-doe',
+    gender: 'Female',
+    dateOfBirth: '1975-03-15',
+    placeOfBirth: {
+        district: 'Kathmandu',
+        address: 'Old Baneshwor',
+    },
+    partyId: 'party-002',
+    partyName: 'Progressive People Party',
+    photoUrl: 'https://example.com/jane-doe-new.jpg', // Changed
+    bio: 'Jane Doe has been a prominent figure in national politics for over two decades, known for her advocacy in social justice and environmental protection. She started her career as a local activist and quickly rose through the ranks of her party. Recently, she has taken on an advisory role for international environmental policy and launched a new youth empowerment initiative.', // Changed
+    province: 'Bagmati',
+    constituency: 'Kathmandu-1',
+    constituencyId: 'const-ktm-1',
+    isActiveInPolitics: true,
+    aliases: ['JD', "The People's Voice", 'Eco-Warrior Jane'], // Changed: Added one
+    positions: [ // Changed: One existing kept, one new added, one old implicitly removed
+      { title: 'Minister of Environment', startDate: '2016-01-10', endDate: '2018-12-20' },
+      { title: 'Advisor, International Environmental Policy', startDate: '2024-07-01', endDate: 'Present' },
+    ],
+    contactInfo: { // Changed: email, website updated, LinkedIn and Instagram added
+      email: 'jane.doe.updated@example.com',
+      phone: '+977-9800000001',
+      officePhone: '+01-4000001',
+      address: 'MP Quarter, Kathmandu',
+      permanentAddress: 'Family Home, Pokhara',
+      website: 'https://janemdoe.np',
+      twitter: '@janedoe_np', // Assuming this remained same
+      facebook: 'facebook.com/janedoeofficial', // Assuming this remained same
+      linkedin: 'linkedin.com/in/janemdoe',
+      instagram: '@janemdoe_official_np',
+    },
+    politicalJourney: [ // Changed: Added one
+      { date: '2000-01-15', event: 'Joined Progressive People Party', description: 'Became an active member of the youth wing.' },
+      { date: '2008-06-01', event: 'Elected as Local Ward Representative', description: 'Served for two years focusing on community projects.' },
+      { date: '2024-06-15', event: 'Launched Youth Empowerment Initiative', description: 'A national program to engage youth in political processes.' },
+    ],
+    partyAffiliations: [ // Changed: Role updated
+        { partyId: 'party-002', partyName: 'Progressive People Party', role: 'Chief Advisor', startDate: '2000-01-15', endDate: 'Present' },
+    ],
+    education: [
+        { institution: 'National University', degree: 'Masters in Political Science', field: 'Political Science', graduationYear: '1998' },
+    ],
+    assetDeclarations: [ // Changed: Value updated, new item added
+        { year: 2022, description: 'House in Kathmandu, Land in Chitwan', value: 'NPR 55,000,000 (Re-evaluated)' },
+        { year: 2023, description: 'Shares in Green Energy Co.', value: 'NPR 5,000,000' },
+    ],
+    criminalRecords: [],
+    committeeMemberships: [ // Changed: Old one removed, new one added
+        { committeeName: 'Advisory Board, Global Green Policy Institute', role: 'Honorary Member', startDate: '2024-07-10', endDate: 'Present'},
+    ],
+    politicalIdeology: ['Social Democracy', 'Environmentalism', 'Youth Empowerment'], // Changed: Added one
+    tags: ['social-justice', 'environment', 'women-rights', 'youth-engagement', 'foreign-policy'], // Changed: Added two
+    dataAiHint: 'Experienced female politician, vibrant, speaking at a podium with youth audience', // Changed
+  } as Partial<Politician>, // Using Partial because not all fields of Politician might be in suggestedData for every edit type
+};
+
+// --- END OF TEMPORARY MOCK DATA ---
+
+interface SideBySideDiffViewerProps {
+  currentEntity: Record<string, any>;
+  pendingEdit: FullEntityEditSuggestion | EntityFieldEditSuggestion;
+}
+
+const getDisplayValue = (value: any): string => {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (value === null || value === undefined) return 'N/A';
+  if (Array.isArray(value)) return `${value.length} items`; // Simple array display for now
+  if (typeof value === 'object') return '{...}'; // Simple object display
+  return String(value);
+};
+
+const renderDiffContent = (current: Record<string, any>, suggested: Record<string, any>, path: string = '') => {
+  const allKeys = new Set([...Object.keys(current), ...Object.keys(suggested)]);
+  const elements: JSX.Element[] = [];
+
+  allKeys.forEach(key => {
+    const currentVal = current[key];
+    const suggestedVal = suggested[key];
+    const currentPath = path ? `${path}.${key}` : key;
+
+    let highlightClass = '';
+    let suggestedDisplay = getDisplayValue(suggestedVal);
+    let currentDisplay = getDisplayValue(currentVal);
+
+    if (JSON.stringify(currentVal) !== JSON.stringify(suggestedVal)) {
+      highlightClass = 'bg-green-100'; // Highlight changes/additions in green
+    }
+
+    if (typeof currentVal === 'object' && currentVal !== null && typeof suggestedVal === 'object' && suggestedVal !== null && !Array.isArray(currentVal) && !Array.isArray(suggestedVal)) {
+      elements.push(
+        <div key={currentPath} className="mb-2">
+          <strong className="text-sm font-semibold capitalize">{key}:</strong>
+          <div className="ml-4 pl-4 border-l border-gray-300">
+            {renderDiffContent(currentVal, suggestedVal, currentPath)}
+          </div>
+        </div>
+      );
+    } else if (Array.isArray(currentVal) || Array.isArray(suggestedVal)) {
+      // Basic array diffing: show items that changed, added, or removed
+      const currentArray = Array.isArray(currentVal) ? currentVal : [];
+      const suggestedArray = Array.isArray(suggestedVal) ? suggestedVal : [];
+      const maxLen = Math.max(currentArray.length, suggestedArray.length);
+      const arrayDiffElements: JSX.Element[] = [];
+
+      for (let i = 0; i < maxLen; i++) {
+        const itemCurrent = currentArray[i];
+        const itemSuggested = suggestedArray[i];
+        let itemHighlight = '';
+        if (JSON.stringify(itemCurrent) !== JSON.stringify(itemSuggested)) {
+          itemHighlight = 'bg-yellow-100 p-1'; // Highlight individual array item changes
+        }
+        if (itemCurrent !== undefined || itemSuggested !== undefined) {
+          arrayDiffElements.push(
+            <div key={`${currentPath}[${i}]`} className={`flex justify-between ${itemHighlight}`}>
+              <div className="w-1/2 pr-1">{itemCurrent !== undefined ? (typeof itemCurrent === 'object' ? JSON.stringify(itemCurrent, null, 2) : getDisplayValue(itemCurrent)) : 'N/A (Removed)'}</div>
+              <div className="w-1/2 pl-1">{itemSuggested !== undefined ? (typeof itemSuggested === 'object' ? JSON.stringify(itemSuggested, null, 2) : getDisplayValue(itemSuggested)) : 'N/A (Removed)'}</div>
+            </div>
+          );
+        }
+      }
+       elements.push(
+        <div key={currentPath} className="mb-2">
+          <strong className="text-sm font-semibold capitalize">{key} (Array):</strong>
+          <div className={`ml-4 p-2 border rounded-md ${highlightClass}`}>
+            {arrayDiffElements.length > 0 ? arrayDiffElements : <span className="text-gray-500">No changes or empty array.</span>}
+          </div>
+        </div>
+      );
+
+
+    } else {
+      elements.push(
+        <div key={currentPath} className="grid grid-cols-3 gap-2 mb-1 text-xs">
+          <div className="font-semibold capitalize col-span-1">{key}:</div>
+          <div className="col-span-1">{currentDisplay}</div>
+          <div className={`col-span-1 ${highlightClass} p-0.5 rounded`}>{suggestedDisplay}</div>
+        </div>
+      );
+    }
+  });
+
+  return <>{elements}</>;
+};
+
+
+const SideBySideDiffViewer: React.FC<SideBySideDiffViewerProps> = ({ currentEntity, pendingEdit }) => {
+  const suggestedData = pendingEdit.suggestionType === 'EDIT_ENTITY_FIELD' 
+    ? { [pendingEdit.fieldPath]: pendingEdit.suggestedValue } 
+    : pendingEdit.suggestedData || {};
+  
+  const currentDataForDiff = pendingEdit.suggestionType === 'EDIT_ENTITY_FIELD'
+    ? { [pendingEdit.fieldPath]: pendingEdit.oldValue }
+    : currentEntity;
+
+
+  return (
+    <div className="flex space-x-4 p-4 border rounded-lg shadow-sm bg-white">
+      <div className="w-1/2">
+        <h2 className="text-lg font-semibold mb-3 text-gray-700">Current Entity</h2>
+        {/* This panel will show the relevant parts of currentEntity. For simplicity, 
+            renderDiffContent will handle showing current vs suggested side-by-side internally per field.
+            So, we call renderDiffContent once and it produces the two-column feel at the field level.
+            The left panel header is conceptual; the actual rendering logic produces both columns.
+         */}
+      </div>
+      <div className="w-1/2">
+        <h2 className="text-lg font-semibold mb-3 text-blue-700">Suggested Changes</h2>
+      </div>
+      {/* The renderDiffContent function actually renders both columns for each field */}
+    </div>
+    // The actual rendering of side-by-side fields happens within renderDiffContent for each key.
+    // The top-level div structure is a bit misleading if renderDiffContent handles both sides.
+    // Let's adjust to have renderDiffContent render its output directly.
+  );
+};
+
+// Corrected main component structure for clarity:
+const SideBySideDiffViewerCorrected: React.FC<SideBySideDiffViewerProps> = ({ currentEntity, pendingEdit }) => {
+  const suggestedChanges = pendingEdit.suggestionType === 'EDIT_ENTITY_FIELD'
+    ? { [pendingEdit.fieldPath]: pendingEdit.suggestedValue }
+    : pendingEdit.suggestedData || {};
+
+  // If it's a field edit, we only want to diff that specific field against its old value.
+  // Otherwise, we diff the full currentEntity against the full suggestedData.
+  const currentDataForDiff = pendingEdit.suggestionType === 'EDIT_ENTITY_FIELD'
+    ? { [pendingEdit.fieldPath]: (pendingEdit as EntityFieldEditSuggestion).oldValue }
+    : currentEntity;
+  
+  const dataToDiffAgainst = pendingEdit.suggestionType === 'EDIT_ENTITY_FIELD'
+    ? { [pendingEdit.fieldPath]: (pendingEdit as EntityFieldEditSuggestion).suggestedValue }
+    : suggestedChanges;
+
+
+  return (
+    <div className="p-4 border rounded-lg shadow-sm bg-white text-sm">
+      <div className="grid grid-cols-3 gap-2 mb-2 pb-1 border-b">
+        <div className="font-bold text-gray-600">Field</div>
+        <div className="font-bold text-gray-600">Current Value</div>
+        <div className="font-bold text-blue-600">Suggested Value</div>
+      </div>
+      {renderDiffContent(currentDataForDiff, dataToDiffAgainst)}
+    </div>
+  );
+};
+
+
+// Example Usage (can be removed or kept for testing)
+export const ExampleDiffViewer: React.FC = () => (
+  <div className="p-8 bg-gray-50 min-h-screen">
+    <h1 className="text-2xl font-bold mb-6">Politician Profile Edit Suggestion</h1>
+    <SideBySideDiffViewerCorrected currentEntity={mockCurrentPolitician} pendingEdit={mockPendingEditPolitician} />
+  </div>
+);
+
+// Default export the corrected component
+export default SideBySideDiffViewerCorrected;
+// export { SideBySideDiffViewerCorrected as SideBySideDiffViewer }; // Alternative export
+
+// Type guard for checking FullEntityEditSuggestion
+// function isFullEntityEdit(edit: FullEntityEditSuggestion | EntityFieldEditSuggestion): edit is FullEntityEditSuggestion {
+//   return edit.suggestionType === 'EDIT_ENTITY_FULL';
+// }
+// Type guard for checking EntityFieldEditSuggestion
+// function isFieldEdit(edit: FullEntityEditSuggestion | EntityFieldEditSuggestion): edit is EntityFieldEditSuggestion {
+//  return edit.suggestionType === 'EDIT_ENTITY_FIELD';
+// }
+
+// Note: The `suggestedData` in `mockPendingEditPolitician` is defined as `Partial<Politician>`.
+// For a `FullEntityEditSuggestion`, it should ideally be the complete entity.
+// The diffing logic should handle cases where keys might be missing if the types allow.
+// The current mock for `FullEntityEditSuggestion` has most fields, which is good for testing.
+// The type for `suggestedData` in `FullEntityEditSuggestion` is `Record<string, any>`,
+// so it can indeed be partial if that's how edits are structured. For this component,
+// it's better if `suggestedData` in `FullEntityEditSuggestion` contains the full new state.
+// The mock has been updated to reflect this more closely.
+// The `Partial<Politician>` cast on `mockPendingEditPolitician.suggestedData` was for initial mock setup;
+// the actual `FullEntityEditSuggestion` type uses `Record<string, any>`.
+// The mock data for `suggestedData` in `mockPendingEditPolitician` should represent the complete state of the entity after changes.
+// I have updated the mock data to be more complete for `suggestedData`.
+// Also, removed the `id` from `mockPendingEditPolitician.suggestedData` as it's usually not part of the "data to change".
+// The `slug` and other identifiers would be part of `suggestedData` if they are changeable.
+// The `currentEntity` and `suggestedData` should align in structure for the diff to work well.
+// Added type assertions (e.g., `as Position[]`) to mock data for stricter typing.
+// Simplified array diffing logic to show current and suggested side-by-side rather than complex patch calculations.
+// Object diffing is recursive.
+// Adjusted mock `suggestedData` to be a more complete representation for `FullEntityEditSuggestion`.
+// Corrected `status: 'PendingUpdate'` to `'PendingEntityUpdate'` in mock.
+// Corrected initial `SideBySideDiffViewer` structure to `SideBySideDiffViewerCorrected` which makes more sense.

--- a/src/components/ui/VersionHistoryDiffViewer.tsx
+++ b/src/components/ui/VersionHistoryDiffViewer.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import type { EntityRevision, Politician, ContactInfo, Position, PoliticalJourneyEvent, PartyAffiliation, EducationEntry, AssetDeclaration, CriminalRecord, CommitteeMembership, PlaceOfBirth } from '@/types/gov';
+
+// --- START OF TEMPORARY MOCK DATA ---
+
+const basePoliticianSnapshot: Omit<Politician, 'id'> = {
+  name: 'John Public',
+  nepaliName: 'जोन पब्लिक',
+  slug: 'john-public',
+  gender: 'Male',
+  dateOfBirth: '1975-03-20',
+  placeOfBirth: {
+    district: 'Lalitpur',
+    address: 'Patan Durbar Square',
+  } as PlaceOfBirth,
+  partyId: 'party-alpha',
+  partyName: 'Alpha Party',
+  photoUrl: 'https://example.com/john_public.jpg',
+  province: 'Bagmati',
+  constituency: 'Lalitpur-3',
+  constituencyId: 'const-ltp-3',
+  isActiveInPolitics: true,
+  education: [
+    { institution: 'Tribhuvan University', degree: 'M.A. in Sociology', field: 'Sociology', graduationYear: '2002' },
+  ] as EducationEntry[],
+  criminalRecords: [] as CriminalRecord[],
+  politicalIdeology: ['Local Development', 'Community Empowerment'] as string[],
+  languagesSpoken: ['Nepali', 'Newari', 'English'] as string[],
+  tags: ['local-development', 'lalitpur', 'cultural-heritage'],
+  dataAiHint: 'A friendly male politician, John Public, in his late 40s.',
+};
+
+const mockRevision1: EntityRevision<Politician> = {
+  id: 'revision-001-politician-jp',
+  entityId: 'politician-jp-001',
+  entityType: 'Politician',
+  date: '2023-01-15T10:00:00Z',
+  author: 'Admin User',
+  event: 'Initial profile creation.',
+  entitySnapshot: {
+    ...basePoliticianSnapshot,
+    id: 'politician-jp-001',
+    bio: 'John Public has served the people of Lalitpur for many years. He is a strong advocate for local development and cultural preservation.',
+    aliases: ['JP', "The People's Man"],
+    positions: [
+      { title: 'Ward Chairperson', startDate: '2010-05-01', endDate: '2015-04-30' },
+      { title: 'Member of Provincial Assembly', startDate: '2017-12-10', endDate: '2022-11-01' },
+    ] as Position[],
+    contactInfo: {
+      email: 'john.public.initial@example.com',
+      phone: '+977-9811111111',
+      officePhone: '+01-5500001',
+      address: 'Provincial Assembly Office, Lalitpur',
+      website: 'https://johnpublic-initial.np',
+    } as ContactInfo,
+    politicalJourney: [
+      { date: '2005-01-10', event: 'Joined Alpha Party', description: 'Began official political affiliation.' },
+      { date: '2010-05-01', event: 'Elected Ward Chairperson', description: 'First major electoral victory.' },
+    ] as PoliticalJourneyEvent[],
+    partyAffiliations: [
+      { partyId: 'party-alpha', partyName: 'Alpha Party', role: 'District Committee Member', startDate: '2008-01-01', endDate: '2022-12-31' },
+    ] as PartyAffiliation[],
+    assetDeclarations: [
+      { year: 2022, description: 'Apartment in Lalitpur, ancestral land in Kavre', value: 'NPR 15,000,000' },
+    ] as AssetDeclaration[],
+    committeeMemberships: [
+      { committeeName: 'Provincial Committee on Local Governance', role: 'Member', startDate: '2018-02-01', endDate: '2022-11-01' },
+    ] as CommitteeMembership[],
+  },
+};
+
+const mockRevision2: EntityRevision<Politician> = {
+  id: 'revision-002-politician-jp',
+  entityId: 'politician-jp-001',
+  entityType: 'Politician',
+  date: '2023-08-20T14:30:00Z',
+  author: 'System Update',
+  event: 'Updated bio, added new position, and modified contact information.',
+  entitySnapshot: {
+    ...basePoliticianSnapshot,
+    id: 'politician-jp-001',
+    bio: 'John Public, a dedicated public servant, has represented Lalitpur with distinction for over a decade. His focus remains on sustainable local development, cultural heritage, and enhancing community participation in governance. He recently spearheaded a successful water management project.',
+    aliases: ['JP', "The People's Man", 'Mr. Development'],
+    positions: [
+      { title: 'Member of Provincial Assembly', startDate: '2017-12-10', endDate: '2022-11-01' },
+      { title: 'Provincial Minister for Infrastructure Development', startDate: '2023-02-01', endDate: 'Present' },
+    ] as Position[],
+    contactInfo: {
+      ...mockRevision1.entitySnapshot.contactInfo,
+      email: 'john.public.minister@example.com',
+      website: 'https://johnpublicminister.np',
+      linkedin: 'https://linkedin.com/in/johnpublicminister',
+    } as ContactInfo,
+    politicalJourney: [
+      ...(mockRevision1.entitySnapshot.politicalJourney || []),
+      { date: '2023-02-01', event: 'Appointed Provincial Minister for Infrastructure', description: 'Took oath for the new ministerial role.' },
+    ] as PoliticalJourneyEvent[],
+    partyAffiliations: [
+      { partyId: 'party-alpha', partyName: 'Alpha Party', role: 'Senior Leader & Provincial Incharge', startDate: '2008-01-01', endDate: 'Present' },
+    ] as PartyAffiliation[],
+    assetDeclarations: [
+      { year: 2022, description: 'Apartment in Lalitpur, ancestral land in Kavre', value: 'NPR 16,500,000 (Re-evaluated)' },
+      { year: 2023, description: 'Investment in Local Cooperative', value: 'NPR 2,000,000' },
+    ] as AssetDeclaration[],
+    committeeMemberships: [
+      { committeeName: 'Provincial Infrastructure Development Board', role: 'Chairperson (Ex-officio)', startDate: '2023-02-15', endDate: 'Present' },
+    ] as CommitteeMembership[],
+    // Added a new field not present in revision 1 for testing removal/addition highlighting
+    awards: ['Community Service Award 2023'] 
+  },
+};
+// --- END OF TEMPORARY MOCK DATA ---
+
+interface VersionHistoryDiffViewerProps {
+  revision1: EntityRevision<any>;
+  revision2: EntityRevision<any>;
+}
+
+const getDisplayValue = (value: any): string => {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (value === null || value === undefined) return 'N/A';
+  if (Array.isArray(value)) return `${value.length} items`;
+  if (typeof value === 'object') return '{...}';
+  return String(value);
+};
+
+const renderSnapshotDiffContent = (
+  snapshot1: Record<string, any>,
+  snapshot2: Record<string, any>,
+  path: string = ''
+): JSX.Element[] => {
+  const allKeys = new Set([...Object.keys(snapshot1), ...Object.keys(snapshot2)]);
+  const elements: JSX.Element[] = [];
+
+  allKeys.forEach(key => {
+    const val1 = snapshot1[key];
+    const val2 = snapshot2[key];
+    const currentPath = path ? `${path}.${key}` : key;
+
+    let val1Display = getDisplayValue(val1);
+    let val2Display = getDisplayValue(val2);
+    let highlightClassVal1 = '';
+    let highlightClassVal2 = '';
+
+    if (JSON.stringify(val1) !== JSON.stringify(val2)) {
+      if (val1 === undefined) { // Added in revision2
+        highlightClassVal2 = 'bg-green-100 p-0.5 rounded';
+        val1Display = 'N/A (Field Added)';
+      } else if (val2 === undefined) { // Removed in revision2
+        highlightClassVal1 = 'bg-red-100 p-0.5 rounded line-through';
+        val2Display = 'N/A (Field Removed)';
+      } else { // Modified
+        highlightClassVal2 = 'bg-yellow-100 p-0.5 rounded';
+      }
+    }
+
+    if (typeof val1 === 'object' && val1 !== null && !Array.isArray(val1) || 
+        typeof val2 === 'object' && val2 !== null && !Array.isArray(val2)) {
+      elements.push(
+        <div key={currentPath} className="mb-2 col-span-3">
+          <strong className="text-sm font-semibold capitalize">{key}:</strong>
+          <div className="ml-4 pl-4 border-l border-gray-300 grid grid-cols-3 gap-2">
+            {/* Header for nested object columns - conceptual, actual fields will align below */}
+            <div className="col-span-1"></div> {/* Placeholder for key name column within nested */}
+            <div className="col-span-1 font-xs text-gray-500 italic">Revision 1</div>
+            <div className="col-span-1 font-xs text-gray-500 italic">Revision 2</div>
+            {renderSnapshotDiffContent(val1 || {}, val2 || {}, currentPath)}
+          </div>
+        </div>
+      );
+    } else if (Array.isArray(val1) || Array.isArray(val2)) {
+      const arr1 = Array.isArray(val1) ? val1 : [];
+      const arr2 = Array.isArray(val2) ? val2 : [];
+      const maxLen = Math.max(arr1.length, arr2.length);
+      const arrayDiffElements: JSX.Element[] = [];
+
+      for (let i = 0; i < maxLen; i++) {
+        const item1 = arr1[i];
+        const item2 = arr2[i];
+        let itemHighlight = '';
+        if (JSON.stringify(item1) !== JSON.stringify(item2)) {
+          itemHighlight = 'bg-yellow-50'; // Light yellow for changed array items
+        }
+        if (item1 !== undefined || item2 !== undefined) {
+          arrayDiffElements.push(
+            <div key={`${currentPath}[${i}]`} className={`flex justify-between text-xs py-0.5 ${itemHighlight}`}>
+              <div className="w-1/2 pr-1 break-all">{item1 !== undefined ? (typeof item1 === 'object' ? JSON.stringify(item1) : getDisplayValue(item1)) : 'N/A'}</div>
+              <div className="w-1/2 pl-1 break-all">{item2 !== undefined ? (typeof item2 === 'object' ? JSON.stringify(item2) : getDisplayValue(item2)) : 'N/A'}</div>
+            </div>
+          );
+        }
+      }
+       elements.push(
+        <React.Fragment key={currentPath}>
+          <div className="font-semibold capitalize col-span-1 py-1">{key} (Array):</div>
+          <div className={`col-span-2 p-1 border rounded-md ${highlightClassVal2 || highlightClassVal1}`}>
+             {arrayDiffElements.length > 0 ? arrayDiffElements : <span className="text-gray-400 text-xs">No items or no changes.</span>}
+          </div>
+        </React.Fragment>
+      );
+    } else {
+      elements.push(
+        <React.Fragment key={currentPath}>
+          <div className="font-semibold capitalize col-span-1 py-0.5">{key}:</div>
+          <div className={`col-span-1 py-0.5 ${highlightClassVal1}`}>{val1Display}</div>
+          <div className={`col-span-1 py-0.5 ${highlightClassVal2}`}>{val2Display}</div>
+        </React.Fragment>
+      );
+    }
+  });
+  return elements;
+};
+
+const RevisionMetadataCard: React.FC<{ revision: EntityRevision<any> }> = ({ revision }) => (
+  <div className="mb-4 p-3 border rounded-md bg-gray-50 shadow-sm">
+    <h3 className="text-md font-semibold text-gray-700">
+      Revision ID: <span className="font-normal text-gray-600">{revision.id}</span>
+    </h3>
+    <p className="text-xs text-gray-500">
+      Date: <span className="font-medium text-gray-600">{new Date(revision.date).toLocaleString()}</span>
+    </p>
+    <p className="text-xs text-gray-500">
+      Author: <span className="font-medium text-gray-600">{revision.author}</span>
+    </p>
+    <p className="text-xs text-gray-500">
+      Event: <span className="font-medium text-gray-600">{revision.event}</span>
+    </p>
+  </div>
+);
+
+const VersionHistoryDiffViewer: React.FC<VersionHistoryDiffViewerProps> = ({ revision1, revision2 }) => {
+  if (!revision1 || !revision2) {
+    return <div className="p-4 text-red-500">Error: Both revisions must be provided.</div>;
+  }
+
+  return (
+    <div className="p-4 bg-white text-xs">
+      <div className="flex space-x-6">
+        <div className="w-1/2">
+          <RevisionMetadataCard revision={revision1} />
+        </div>
+        <div className="w-1/2">
+          <RevisionMetadataCard revision={revision2} />
+        </div>
+      </div>
+
+      <div className="mt-4 p-3 border rounded-lg shadow-sm">
+        <div className="grid grid-cols-3 gap-2 mb-2 pb-1 border-b">
+          <div className="font-bold text-gray-600">Field</div>
+          <div className="font-bold text-gray-600">Revision 1 ({new Date(revision1.date).toLocaleDateString()})</div>
+          <div className="font-bold text-blue-600">Revision 2 ({new Date(revision2.date).toLocaleDateString()})</div>
+        </div>
+        {renderSnapshotDiffContent(revision1.entitySnapshot, revision2.entitySnapshot)}
+      </div>
+    </div>
+  );
+};
+
+// Example Usage (can be removed or kept for testing)
+export const ExampleVersionHistoryViewer: React.FC = () => (
+  <div className="p-8 bg-gray-100 min-h-screen">
+    <h1 className="text-2xl font-bold mb-6 text-center">Politician Version History Comparison</h1>
+    <VersionHistoryDiffViewer revision1={mockRevision1} revision2={mockRevision2} />
+  </div>
+);
+
+export default VersionHistoryDiffViewer;
+</code_block>


### PR DESCRIPTION
…history

This commit introduces two new UI components for displaying differences between data objects:

1.  **SideBySideDiffViewer**:
    *   Located at `src/components/ui/SideBySideDiffViewer.tsx`.
    *   Designed for moderation workflows, it compares a current entity with a pending edit suggestion (`FullEntityEditSuggestion` or `EntityFieldEditSuggestion`).
    *   Highlights changes, additions, and deletions field by field, including nested objects and arrays.
    *   Currently uses embedded mock data due to an intermittent issue with writing to `src/lib/mock-data.ts`.

2.  **VersionHistoryDiffViewer**:
    *   Located at `src/components/ui/VersionHistoryDiffViewer.tsx`.
    *   Compares two `EntityRevision` snapshots of an entity.
    *   Displays metadata (author, date, event) for each revision.
    *   Highlights changes, additions, and deletions between the two snapshots.
    *   Also uses embedded mock data for the same reason mentioned above.

A temporary test page has been added at `src/app/(app)/diff-test/page.tsx` to demonstrate and visually test these components.

The diffing logic is implemented directly within the components without external libraries. Styling is done using Tailwind CSS.