### PR TITLE
Fix: Center page content by adjusting main layout flex properties

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -21,7 +21,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             - overflow-y-auto: Enables vertical scrolling within the main content if it exceeds viewport height.
             - Centering and padding are now handled by a nested div.
           */}
-          <main className="flex-1 overflow-y-auto">
+          <main className="flex-1 overflow-y-auto flex justify-center">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">
               {children}
             </div>


### PR DESCRIPTION
The page content was previously appearing shifted to the left. This was likely due to the main content container not being properly centered within its available space.

This commit modifies `src/components/layout/app-layout.tsx` by adding `flex` and `justify-center` to the Tailwind CSS classes of the `<main>` HTML5 element. This change ensures that the direct child of `<main>` (the `div.container`) is horizontally centered, resolving the layout shift.