### PR TITLE
feat: Enhance admin section visibility and UI

### DIFF
--- a/src/app/admin/suggestions/page.tsx
+++ b/src/app/admin/suggestions/page.tsx
@@ -18,6 +18,52 @@ import {
 } from '@/lib/data/suggestions';
 import Link from 'next/link';
 
+// Helper component to display JSON data in a more readable format
+const JsonDisplay = ({ data, level = 0 }: { data: any; level?: number }) => {
+  if (data === null || data === undefined) {
+    return <span className="text-muted-foreground italic">N/A</span>;
+  }
+
+  // Handle arrays
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return <span className="text-muted-foreground italic">[Empty Array]</span>;
+    }
+    return (
+      <ul style={{ paddingLeft: `${level > 0 ? 20 : 0}px` }} className="list-none space-y-1 mt-1">
+        {data.map((item, index) => (
+          <li key={index} className="p-1 rounded-md bg-muted/30">
+            <JsonDisplay data={item} level={level + 1} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  // Handle simple types (strings, numbers, booleans)
+  if (typeof data !== 'object') {
+    return <span className="break-all">{String(data)}</span>;
+  }
+
+  // Handle empty objects
+  if (Object.keys(data).length === 0) {
+    return <span className="text-muted-foreground italic">{'{ Empty Object }'}</span>;
+  }
+
+  // Handle objects
+  return (
+    <div style={{ marginLeft: `${level > 0 ? 20 : 0}px` }} className="space-y-2 pt-1">
+      {Object.entries(data).map(([key, value]) => (
+        <div key={key} className="flex flex-col">
+          <strong className="mr-2 shrink-0 text-sm text-foreground/90">{key}:</strong>
+          <div className="break-all text-sm text-foreground/80 pl-2 border-l-2 border-muted">
+            <JsonDisplay data={value} level={level + 1} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default function AdminSuggestionsPage() {
   const [isClient, setIsClient] = useState(false);
@@ -147,9 +193,9 @@ export default function AdminSuggestionsPage() {
                   <div className="space-y-4 text-sm">
                     <div>
                       <h4 className="font-semibold mb-1">Proposed Data:</h4>
-                      <pre className="p-2 bg-muted rounded-md text-xs whitespace-pre-wrap break-all">
-                        {JSON.stringify(suggestion.proposedData, null, 2)}
-                      </pre>
+                      <div className="p-2 bg-muted rounded-md text-xs">
+                        <JsonDisplay data={suggestion.proposedData} />
+                      </div>
                     </div>
 
                     {suggestion.reasonForChange && (

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -769,6 +769,9 @@ import {
   SettingsIcon,
   PanelLeftOpen,
   ShieldCheck,
+  ScrollText,
+  Database,
+  UserCog,
 } from "lucide-react"
 import { usePathname } from "next/navigation"
 import { entityNavItems } from "@/lib/navigation";
@@ -846,6 +849,42 @@ export function AppEntitySidebar() {
                   <Link href="/admin/suggestions">
                     <Gavel />
                     <span>Suggestions</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname.startsWith("/admin/audit-log")}
+                  tooltip={{ children: "Audit Log", side: "right", align: "center", sideOffset: 8 }}
+                >
+                  <Link href="/admin/audit-log">
+                    <ScrollText />
+                    <span>Audit Log</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname.startsWith("/admin/data-management")}
+                  tooltip={{ children: "Data Management", side: "right", align: "center", sideOffset: 8 }}
+                >
+                  <Link href="/admin/data-management">
+                    <Database />
+                    <span>Data Management</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname.startsWith("/admin/users")}
+                  tooltip={{ children: "User Management", side: "right", align: "center", sideOffset: 8 }}
+                >
+                  <Link href="/admin/users">
+                    <UserCog />
+                    <span>User Management</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>


### PR DESCRIPTION
This commit introduces two main improvements to the admin section:

1.  **Admin Links in Sidebar:**
    - All admin pages (Suggestions, Audit Log, Data Management, User Management) are now accessible via links in the main sidebar when an admin or editor user is logged in.
    - Appropriate icons have been added for each link.
    - This addresses the issue of admin pages not being easily discoverable.

2.  **Improved `proposedData` Display:**
    - On the Admin Suggestions page, the `proposedData` field (which contains JSON data for suggested edits) is now rendered in a more human-readable, structured format using a new `JsonDisplay` component.
    - This new component recursively displays objects and arrays with clear key-value pairs and indentation, replacing the previous raw JSON string output.
    - This significantly improves the usability of the suggestions review process.

Other admin pages were reviewed and confirmed to be using existing UI components adequately, not just displaying raw JSON. The changes ensure that you can easily access and manage administrative functions if you have the appropriate role (Admin, SuperAdmin, Editor).