### PR TITLE
Refactor: Update header/sidebar layout and logo placement

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -12,7 +12,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <SidebarProvider>
       <div className="min-h-screen flex flex-col bg-background">
-        <AppHeader />
+        {/* AppHeader is MOVED FROM HERE */}
         <div className="flex flex-1 overflow-hidden"> {/* Added overflow-hidden to parent flex */}
           <AppEntitySidebar />
           {/* 
@@ -21,7 +21,9 @@ export function AppLayout({ children }: AppLayoutProps) {
             - overflow-y-auto: Enables vertical scrolling within the main content if it exceeds viewport height.
             - Centering and padding are now handled by a nested div.
           */}
-          <main className="flex-1 overflow-y-auto flex justify-center">
+          <main className="flex-1 overflow-y-auto flex flex-col"> {/* Added flex-col here */}
+            <AppHeader /> {/* New position: Inside main, will be sticky to main's scroll area */}
+            {/* The existing content wrapper div */}
             <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">
               {children}
             </div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -86,12 +86,8 @@ export function AppHeader() {
   const showAdminLinksInMobile = user && canAccess(currentUserForRoles.role, EDITOR_ROLES);
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between">
-        <Link href="/feed" className="flex items-center gap-2 text-lg font-headline font-semibold text-primary">
-          <ShieldCheck className="h-7 w-7" />
-          <span>GovTrackr</span>
-        </Link>
 
         <nav className="hidden lg:flex items-center space-x-1 text-sm font-medium">
           {mainNavLinks.map((link) => {
@@ -181,10 +177,6 @@ export function AppHeader() {
               <SheetContent side="right" className="w-[280px] sm:w-[320px] p-0">
                  <SheetHeader className="p-4 border-b border-sidebar-border">
                   <SheetTitle className="text-lg font-semibold text-primary sr-only">Mobile Menu</SheetTitle>
-                   <Link href="/feed" className="flex items-center gap-2 text-lg font-headline font-semibold text-primary" onClick={() => setIsSheetOpen(false)}>
-                    <ShieldCheck className="h-7 w-7" />
-                    <span>GovTrackr</span>
-                  </Link>
                 </SheetHeader>
                 <div className="p-4">
                   <form onSubmit={handleSearchSubmit} className="relative mb-4">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -802,15 +802,19 @@ export function AppEntitySidebar() {
       collapsible="icon"
       className="hidden md:flex flex-col bg-card border-r border-border shadow-sm"
     >
-      <SidebarHeader className="flex items-center justify-end h-16"> {/* Changed justify-between to justify-end */}
+      <SidebarHeader className="flex items-center justify-between h-16"> {/* Changed back to justify-between */}
+        <Link href="/feed" className={cn("flex items-center gap-2 text-xl font-headline font-semibold text-primary", state === "collapsed" && "hidden")}>
+          <ShieldCheck className="h-7 w-7" />
+          <span>GovTrackr</span>
+        </Link>
         <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+          variant="outline" /* Changed from ghost */
+          size="icon" /* size="icon" usually means padding is handled by h-X w-X */
+          className="h-10 w-10 text-muted-foreground hover:text-foreground" /* Increased size */
           onClick={toggleSidebar}
           aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
         >
-          <PanelLeftOpen className={cn("h-5 w-5 transition-transform duration-300", open && "rotate-180")} />
+          <PanelLeftOpen className={cn("h-6 w-6 transition-transform duration-300", open && "rotate-180")} /> {/* Increased icon size */}
         </Button>
       </SidebarHeader>
       <SidebarContent className="pt-2">


### PR DESCRIPTION
Based on your feedback, I've made the following changes:

- Moved the logo from the AppHeader to the AppEntitySidebar.
  - The logo is now displayed in the sidebar header when expanded.
  - The logo is removed from the main AppHeader and its mobile sheet menu.
- Restructured AppLayout to position AppHeader within the main content area.
  - This makes the header's width relative to the content area alongside the sidebar, effectively making it "smaller" and preventing overlap.
- Enhanced the visibility of the sidebar toggle button.
  - I increased the button size and changed its variant to 'outline' for better prominence.
- Reverted a previous change that made the header background fully opaque.

These changes aim to align the application's layout with the requested design, prioritizing the sidebar for logo placement and adjusting the header's relationship with the sidebar.