### PR TITLE
feat: Modernize page layout and typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,6 @@
   body {
     @apply bg-background text-foreground;
     /* Consider adding font-antialiased for smoother text rendering */
-    /* @apply font-antialiased; */
+  @apply font-antialiased;
   }
 }

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -24,7 +24,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           <main className="flex-1 overflow-y-auto flex flex-col"> {/* Added flex-col here */}
             <AppHeader /> {/* New position: Inside main, will be sticky to main's scroll area */}
             {/* The existing content wrapper div */}
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">
+            <div className="mx-auto w-full px-4 sm:px-6 md:px-8 py-6 md:py-8 lg:max-w-screen-xl xl:max-w-screen-2xl">
               {children}
             </div>
           </main>


### PR DESCRIPTION
This commit introduces changes to enhance the application's visual appeal and user experience by:

1.  **Widening the Main Content Container:** Modified `src/components/layout/app-layout.tsx` to increase the maximum width of the primary content area on larger screens:
    - `lg` screens now use `max-w-screen-xl` (1280px).
    - `xl` screens and above now use `max-w-screen-2xl` (1536px). This provides more horizontal space for content, contributing to a more modern, less cramped feel on desktops. Horizontal padding has also been standardized to `md:px-8` (2rem from medium screens up) within this container.

2.  **Improving Typography:** Enabled `font-antialiased` for the `body` in `src/app/globals.css`. This results in smoother text rendering across the application, enhancing readability and overall visual polish.

Spacing on Elections and Promises list pages was reviewed and found to be already well-structured with consistent margins, requiring no further changes for those specific layouts. Existing hover effects on cards were also deemed appropriate.