### PR TITLE
fix: Correct antialiasing implementation to resolve build failure

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,7 @@
   body {
     @apply bg-background text-foreground;
     /* Consider adding font-antialiased for smoother text rendering */
-  @apply font-antialiased;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   }
 }


### PR DESCRIPTION
This commit fixes a build error caused by the previous attempt to apply `font-antialiased` using `@apply` in `src/app/globals.css`.

The `font-antialiased` utility was not being correctly recognized in the Vercel build environment when applied via `@apply` within the base layer.

The fix involves replacing:
`@apply font-antialiased;`
with the direct CSS properties:
`-webkit-font-smoothing: antialiased;`
`-moz-osx-font-smoothing: grayscale;`
within the `body` styles in `src/app/globals.css`.

This change ensures that font smoothing is applied correctly for a more refined text appearance across the application, while also resolving the previous build issue. All other changes from the prior commit on this branch (wider page container) are retained.